### PR TITLE
git commit -m "feat(ffmpeg): add insecure download option for network…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,15 +42,27 @@ execute_process(
 # Download prebuilt ffmpeg
 set(FFMPEG_ZIP_PATH "${CMAKE_BINARY_DIR}/externals/ffmpeg-${FFMPEG_GIT_SHA}.zip")
 if(NOT EXISTS "${FFMPEG_ZIP_PATH}")
-	message(STATUS "Downloading FFMPEG prebuilts...")
-	file(DOWNLOAD https://github.com/shadps4-emu/ext-ffmpeg-core/releases/download/${FFMPEG_GIT_SHA}/${FFMPEG_PREBUILTS_NAME}
-			"${FFMPEG_ZIP_PATH}" SHOW_PROGRESS
-		STATUS FILE_STATUS)
-	list(GET FILE_STATUS 0 STATUS_CODE)
-	if (NOT STATUS_CODE EQUAL 0)
-		file(REMOVE "${FFMPEG_ZIP_PATH}") # CMake create 0 byte file even if URL is invalid. So need to delete it.
-		message(FATAL_ERROR "No FFMPEG prebuilt found with corresponding commit SHA (${FFMPEG_GIT_SHA})")
-	endif()
+    message(STATUS "Downloading FFMPEG prebuilts...")
+    
+    set(FFMPEG_INSECURE "NO" CACHE STRING "Disable SSL verification? (YES/NO)")
+    
+    set(DOWNLOAD_OPTS SHOW_PROGRESS STATUS FILE_STATUS)
+    if(FFMPEG_INSECURE MATCHES "^(YES|Y)$")
+        message(STATUS "Downloading with SSL disabled...")
+        set(DOWNLOAD_OPTS ${DOWNLOAD_OPTS} TLS_VERIFY OFF LOG download_log)
+    endif()
+    
+    file(DOWNLOAD 
+        "https://github.com/shadps4-emu/ext-ffmpeg-core/releases/download/${FFMPEG_GIT_SHA}/${FFMPEG_PREBUILTS_NAME}"
+        "${FFMPEG_ZIP_PATH}" 
+        ${DOWNLOAD_OPTS}
+    )
+    
+    list(GET FILE_STATUS 0 STATUS_CODE)
+    if(STATUS_CODE)
+        file(REMOVE "${FFMPEG_ZIP_PATH}")
+        message(FATAL_ERROR "Download failed! Use: cmake .. -DFFMPEG_INSECURE=YES")
+    endif()
 endif()
 
 set(FFMPEG_LIB_PATH "${CMAKE_BINARY_DIR}/externals/ffmpeg-${FFMPEG_GIT_SHA}/lib")


### PR DESCRIPTION
… restrictions

Add FFMPEG_INSECURE cache variable to allow disabling SSL verification during ffmpeg prebuilt download. This helps users behind firewalls or with network restrictions (e.g., GFW) who experience download failures.

Changes:
- Add FFMPEG_INSECURE cache variable (default: NO)
- Add TLS_VERIFY OFF option when FFMPEG_INSECURE=YES
- Add LOG download_log for better debugging
- Improve error message with cmake command hint

Usage:
  cmake .. -DFFMPEG_INSECURE=YES  # disable SSL verification
  cmake .. -DFFMPEG_INSECURE=NO   # normal download (default)

This change maintains backward compatibility and only affects users who explicitly enable the insecure option."